### PR TITLE
Payload chunking

### DIFF
--- a/EIPS/eip-8101.md
+++ b/EIPS/eip-8101.md
@@ -13,7 +13,7 @@ requires: 4844, 4895, 7732, 7825, 7928
 
 ## Abstract
 
-This EIP introduces Payload Chunking, a protocol upgrade that restructures Ethereum block propagation into self-contained execution chunks with separated Chunk Access Lists (CALs). The proposer propagates beacon and execution payload headers, followed by CALs and chunks as independent network sidecars. CALs contain state diffs from chunk execution, enabling parallel chunk validation: chunk N can be validated once CALs 0..N-1 are available. After all chunks validate successfully, the consensus layer finalizes the block. This architecture transforms block validation from a monolithic operation into a streaming pipeline while preserving block atomicity. Chunks exist only as a propagation and validation construct; the canonical chain stores complete execution payloads.
+This EIP introduces Payload Chunking, a protocol upgrade that restructures Ethereum block propagation into self-contained execution chunks with separated Chunk Access Lists (CALs). The proposer propagates beacon and execution payload headers, followed by CALs and chunks as independent network messages. CALs contain state diffs from chunk execution, enabling parallel chunk validation: chunk N can be validated once CALs 0..N are available. After all chunks validate successfully, the consensus layer finalizes the block. This architecture transforms block validation from a monolithic operation into a streaming pipeline while preserving block atomicity. Chunks exist only as a propagation and validation construct; the canonical chain stores complete execution payloads.
 
 ## Motivation
 
@@ -21,6 +21,7 @@ As Ethereum's gas limit increases, block sizes and execution complexity grow cor
 
 This proposal addresses these constraints by:
 
+- **Parallel propagation**: Nodes propagate parts of the block separately, improving propagation speed through the network
 - **Streaming validation**: Execution begins as chunks arrive rather than after full payload receipt
 - **Parallel chunk execution**: CALs provide state diffs enabling independent validation of chunks
 - **Bounded resources**: Per-chunk gas limits (`CHUNK_GAS_LIMIT = 2**24`) bound memory and CPU per validation unit
@@ -36,8 +37,7 @@ This proposal addresses these constraints by:
 | `CHUNK_GAS_LIMIT` | `2**24` (16,777,216) | Maximum gas per chunk, from [EIP-7825](./eip-7825.md) |
 | `MAX_CHUNKS_PER_BLOCK` | `2**8` (256) | Maximum chunks per block |
 | `MAX_TRANSACTIONS_PER_CHUNK` | `2**16` (65,536) | Maximum transactions per chunk |
-| `CHUNK_SUBNET_COUNT` | `64` | Number of gossip subnets for chunk/CAL propagation |
-| `CHUNK_INCLUSION_PROOF_DEPTH` | `floorlog2(MAX_CHUNKS_PER_BLOCK) + 1` (9) | SSZ Merkle proof depth for sidecar inclusion |
+| `CHUNK_INCLUSION_PROOF_DEPTH` | `floorlog2(get_generalized_index(BeaconBlockBody, 'chunk_headers_root')) + 1 + ceillog2(MAX_CHUNKS_PER_BLOCK)` (13) | SSZ Merkle proof depth for message inclusion |
 | `MAX_CAL_SIZE` | `2**24` (16,777,216) | Maximum size in bytes of RLP-encoded CAL |
 
 ### Type Aliases
@@ -49,7 +49,7 @@ Root = Bytes32                      # 32-byte hash (Merkle root or block root)
 
 ### Data Structures
 
-#### Execution Layer Structures
+#### Execution Chunk
 
 ```python
 # Chunk header containing execution commitments
@@ -84,7 +84,7 @@ StorageValue = Bytes32         # Storage slot value
 Balance = uint256              # Account balance
 Nonce = uint64                 # Account nonce
 CodeData = bytes               # Contract bytecode
-TxIndex = uint16               # Transaction index within the chunk (0-indexed relative to chunk start)
+TxIndex = uint16               # Transaction index within the block
 ```
 
 **Change Structures:**
@@ -119,16 +119,33 @@ ChunkAccessList = List[AccountChanges]
 - **First CAL (chunk 0)**: Includes pre-execution system writes ([EIP-2935](./eip-2935.md) block hash history, [EIP-4788](./eip-4788.md) beacon root)
 - **Last CAL (chunk N-1)**: Includes post-execution system operations ([EIP-4895](./eip-4895.md) withdrawals, [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) validator operations)
 
+#### ExecutionPayload and ExecutionPayloadHeader
+
+The `ExecutionPayload` is no longer used and is replaced by `ExecutionPayloadHeader`. 
+
+The `ExecutionPayloadHeader` is modified to include number of chunks in a block:
+
+```python
+class ExecutionPayloadHeader(Container):
+    # ... existing fields ...
+	chunk_count: uint8      # Number of chunks in block
+```
+
 #### Beacon Block Commitments
 
-The beacon block body includes two Merkle roots committing to chunks and CALs:
+The beacon block body replaces `execution_payload` with `execution_payload_header` and includes two Merkle roots committing to chunks and CALs:
 
 ```python
 class BeaconBlockBody(Container):
-    # ... existing fields ...
-    chunk_headers_root: Root            # Commitment to all chunk headers
-    chunk_access_lists_root: Root       # Commitment to all CAL hashes
+    # ... other existing fields ...
+    # Removed `execution_payload`
+    execution_payload_header: ExecutionPayloadHeader    # Execution payload header
+
+    chunk_headers_root: Root                            # Commitment to all chunk headers
+    chunk_access_lists_root: Root                       # Commitment to all CAL hashes
 ```
+
+Note: If [EIP-7732](./eip-7732.md) (ePBS) is enabled, then `execution_payload` field of `ExecutionPayloadEnvelope` is replaced by `execution_payload_header` in the same way.
 
 **Commitment construction:**
 
@@ -144,20 +161,20 @@ chunk_access_lists_root = hash_tree_root(cal_hashes)
 
 Note: The EL uses `keccak256(RLP(CAL))` in chunk headers per [EIP-7928](./eip-7928.md). The CL uses SSZ `hash_tree_root` for inclusion proofs. Both reference the same RLP-encoded CAL data.
 
-#### Network Sidecars
+#### Network Topis
 
-Chunks and CALs propagate as separate network sidecars with SSZ Merkle inclusion proofs against the beacon block commitments.
+Chunks and CALs propagate as separate network message with SSZ Merkle inclusion proofs against the beacon block header.
 
 ```python
-class ExecutionChunkSidecar(Container):
+class ExecutionChunkMessage(Container):
     chunk: ExecutionChunk                                               # The execution chunk
-    inclusion_proof: Vector[Bytes32, CHUNK_INCLUSION_PROOF_DEPTH]       # SSZ Merkle proof against chunk_headers_root
+    inclusion_proof: Vector[Bytes32, CHUNK_INCLUSION_PROOF_DEPTH]       # SSZ Merkle proof against signed_block_header.message.body_root
     signed_block_header: SignedBeaconBlockHeader                        # Signed beacon block header
 
-class ChunkAccessListSidecar(Container):
+class ChunkAccessListMessage(Container):
     chunk_index: ChunkIndex                                             # Chunk index this CAL corresponds to
     chunk_access_list: ByteList[MAX_CAL_SIZE]                           # RLP-encoded chunk access list
-    inclusion_proof: Vector[Bytes32, CHUNK_INCLUSION_PROOF_DEPTH]       # SSZ Merkle proof against chunk_access_lists_root
+    inclusion_proof: Vector[Bytes32, CHUNK_INCLUSION_PROOF_DEPTH]       # SSZ Merkle proof against signed_block_header.message.body_root
     signed_block_header: SignedBeaconBlockHeader                        # Signed beacon block header
 ```
 
@@ -168,11 +185,11 @@ The `signed_block_header` provides the proposer signature for authentication and
 Block producers MUST follow these rules when constructing chunks:
 
 1. **Gas Bound**: Each chunk MUST satisfy `gas_used <= CHUNK_GAS_LIMIT`
-2. **Minimal Chunking**: For any two consecutive chunks i and i+1, their combined gas MUST exceed `CHUNK_GAS_LIMIT`. This ensures chunks cannot be trivially merged, preventing unnecessary fragmentation.
+2. **Minimal Chunking**: For any two consecutive chunks `i` and `i+1`, their combined gas MUST exceed `CHUNK_GAS_LIMIT`. This ensures chunks cannot be trivially merged, preventing unnecessary fragmentation.
 3. **Transaction Atomicity**: Transactions MUST NOT be split across chunks. Each transaction belongs entirely to one chunk.
 4. **Withdrawal Placement**: Withdrawals MUST appear only in the final chunk. All other chunks have empty withdrawal lists.
 5. **Chunk Count Bound**: A block MUST contain at most `MAX_CHUNKS_PER_BLOCK` chunks
-6. **Sequential Indexing**: Chunks MUST be indexed sequentially from 0 to N-1 where N is the total chunk count
+6. **Sequential Indexing**: Chunks MUST be indexed sequentially from `0` to `N-1` where `N` is the total chunk count
 
 ### Network Protocol
 
@@ -182,29 +199,47 @@ Chunks and CALs propagate on dedicated gossip topics:
 
 | Topic | Payload |
 |-------|---------|
-| `execution_chunk_sidecar_{subnet_id}` | `ExecutionChunkSidecar` |
-| `chunk_access_list_sidecar_{subnet_id}` | `ChunkAccessListSidecar` |
+| `execution_chunk` | `ExecutionChunkMessage` |
+| `chunk_access_list` | `ChunkAccessListMessage` |
 
-Subnet assignment follows the pattern: `subnet_id = chunk_index % CHUNK_SUBNET_COUNT`.
+#### Message Validation
 
-#### Sidecar Validation
+Nodes MUST validate messages before forwarding:
 
-Nodes MUST validate sidecars before forwarding:
-
-**ExecutionChunkSidecar validation:**
+**ExecutionChunkMessage validation:**
 1. Verify `signed_block_header.signature` is valid for the proposer at the given slot
 2. Verify `chunk.chunk_header.index < MAX_CHUNKS_PER_BLOCK`
 3. Verify `chunk.chunk_header.gas_used <= CHUNK_GAS_LIMIT`
 4. Verify `hash_tree_root(chunk.transactions) == chunk.chunk_header.txs_root`
-5. Verify `is_valid_merkle_branch(hash_tree_root(chunk.chunk_header), inclusion_proof, CHUNK_INCLUSION_PROOF_DEPTH, chunk.chunk_header.index, chunk_headers_root)` where `chunk_headers_root` is derived from `signed_block_header.message.body_root`
+5. Verify inclusion proof:
+    ```python
+    gindex = get_generalized_index(BeaconBlockBody, 'chunk_headers_root', chunk.chunk_header.index)
+    is_valid_merkle_branch(
+        leaf=hash_tree_root(chunk.chunk_header),
+        branch=inclusion_proof,
+        depth=CHUNK_INCLUSION_PROOF_DEPTH,
+        index=get_subtree_index(gindex),
+        root=signed_block_header.message.body_root,
+    )
+    ```
 
-**ChunkAccessListSidecar validation:**
+**ChunkAccessListMessage validation:**
 1. Verify `signed_block_header.signature` is valid for the proposer at the given slot
 2. Verify `chunk_index < MAX_CHUNKS_PER_BLOCK`
 3. Verify `len(chunk_access_list) <= MAX_CAL_SIZE`
-4. Verify `is_valid_merkle_branch(hash_tree_root(chunk_access_list), inclusion_proof, CHUNK_INCLUSION_PROOF_DEPTH, chunk_index, chunk_access_lists_root)` where `chunk_access_lists_root` is derived from `signed_block_header.message.body_root`
+4. Verify inclusion proof:
+    ```python
+    gindex = get_generalized_index(BeaconBlockBody, 'chunk_access_lists_root', chunk_index)
+    is_valid_merkle_branch(
+        leaf=hash_tree_root(chunk_access_list),
+        branch=inclusion_proof,
+        depth=CHUNK_INCLUSION_PROOF_DEPTH,
+        index=get_subtree_index(gindex),
+        root=signed_block_header.message.body_root,
+    )
+    ```
 
-Nodes MUST subscribe to all chunk and CAL subnets to ensure block availability. Sidecars may be validated immediately using the signed block header without waiting for the full beacon block.
+Nodes MUST subscribe to chunk and CAL topics. Messages may be validated immediately using the signed block header without waiting for the full beacon block.
 
 ### Consensus Layer Changes
 
@@ -241,22 +276,22 @@ class Store:
 CALs are forwarded to the execution layer upon receipt. The EL caches CALs for use in subsequent chunk validation.
 
 ```python
-def on_chunk_access_list_received(store: Store, cal_sidecar: ChunkAccessListSidecar) -> None:
+def on_chunk_access_list_received(store: Store, cal_message: ChunkAccessListMessage) -> None:
     # Derive beacon block root from signed header
-    root = hash_tree_root(cal_sidecar.signed_block_header.message)
-    chunk_index = cal_sidecar.chunk_index
+    root = hash_tree_root(cal_message.signed_block_header.message)
+    chunk_index = cal_message.chunk_index
 
-    # Validate sidecar (proposer signature, inclusion proof, index bounds)
-    assert verify_chunk_access_list_sidecar(cal_sidecar)
+    # Validate cal message (proposer signature, inclusion proof, index bounds)
+    assert verify_chunk_access_list_message(cal_message)
 
     # Wait for beacon block to get execution payload header
     block = wait_for_beacon_block(store, root)
 
     # Forward CAL to execution layer for caching
     execution_engine.new_chunk_access_list(
-        block.body.execution_payload_header,
+        block.body.execution_payload_header.block_hash,
         chunk_index,
-        cal_sidecar.chunk_access_list
+        cal_message.chunk_access_list
     )
 
     # Record CAL receipt and notify waiting chunk validations
@@ -266,17 +301,17 @@ def on_chunk_access_list_received(store: Store, cal_sidecar: ChunkAccessListSide
 
 ##### Phase 2: Chunk Validation
 
-Chunks are validated as they arrive, provided all prerequisite CALs (indices 0 through N-1 for chunk N) are available.
+Chunks are validated as they arrive, provided all prerequisite CALs (indices `0` through `N` for chunk `N`) are available.
 
 ```python
-def on_chunk_received(store: Store, chunk_sidecar: ExecutionChunkSidecar) -> None:
+def on_chunk_received(store: Store, chunk_message: ExecutionChunkMessage) -> None:
     # Derive beacon block root from signed header
-    root = hash_tree_root(chunk_sidecar.signed_block_header.message)
-    chunk = chunk_sidecar.chunk
+    root = hash_tree_root(chunk_message.signed_block_header.message)
+    chunk = chunk_message.chunk
     chunk_index = chunk.chunk_header.index
 
-    # Validate sidecar (proposer signature, inclusion proof, gas bounds, tx root)
-    assert verify_chunk_sidecar(chunk_sidecar)
+    # Validate chunk message (proposer signature, inclusion proof, index bounds, gas bounds, tx root)
+    assert verify_chunk_message(chunk_message)
 
     # Store chunk header for later finalization
     store.chunk_headers[root][chunk_index] = chunk.chunk_header
@@ -290,7 +325,7 @@ def on_chunk_received(store: Store, chunk_sidecar: ExecutionChunkSidecar) -> Non
 
     # Execute chunk via EL (EL has cached all required CALs)
     execution_status = execution_engine.execute_chunk(
-        block.body.execution_payload_header,
+        block.body.execution_payload_header.block_hash,
         chunk
     )
     store.chunk_execution_statuses[root][chunk_index] = execution_status
@@ -315,19 +350,12 @@ def maybe_finalize_block(store: Store, root: Root) -> None:
     chunk_statuses = store.chunk_execution_statuses.get(root, {})
 
     # Verify sequential chunk coverage and validity
-    total_gas_used = 0
-    chunk_count = len(chunk_statuses)
-    for i in range(chunk_count):
+    for i in range(payload_header.chunk_count):
         if i not in chunk_statuses:
             return  # Gap in sequence
         if not chunk_statuses[i].valid:
             store.block_valid[root] = False
             return
-        total_gas_used += chunk_headers[i].gas_used
-
-    # All chunks must be received
-    if total_gas_used != payload_header.gas_used:
-        return
 
     # EL verifies chunk header chaining and final state root
     finalize_result = execution_engine.finalize_block(payload_header.block_hash)
@@ -341,46 +369,44 @@ Validators MUST NOT attest to a block until:
 1. All chunks have been received and individually validated (Phase 2 complete)
 2. Block finalization has succeeded (Phase 3 complete)
 
-**ePBS Integration ([EIP-7732](./eip-7732.md))**: PTC (Payload Timeliness Committee) members attest to chunk and CAL data availability. PTC attestations are independent of execution validity—they confirm only that all sidecars were received within the timeliness window.
+**ePBS Integration ([EIP-7732](./eip-7732.md))**: PTC (Payload Timeliness Committee) members attest to chunk and CAL data availability. PTC attestations are independent of execution validity—they confirm only that all messages were received within the timeliness window.
 
 ### Execution Layer Changes
 
 #### Chunk Execution
 
-The execution layer validates chunks independently. For chunk N, the EL applies CALs 0..N-1 to the parent block state to reconstruct the chunk's pre-state, then executes the chunk transactions.
+The execution layer validates chunks independently. For chunk `N`, the EL applies CALs `0..N-1` to the parent block state to reconstruct the chunk's pre-state, then executes the chunk transactions. It uses CAL `N` to execute transactions in parallel (the same as in [EIP-7928](./eip-7928.md)).
 
 ```python
 def el_execute_chunk(
     payload_header: ExecutionPayloadHeader,
     chunk: ExecutionChunk,
     cached_cals: Dict[ChunkIndex, ChunkAccessList]
-) -> ChunkExecutionStatusV1:
+) -> PayloadStatusV1:
     """Execute chunk using cached CALs to reconstruct pre-state."""
     chunk_index = chunk.chunk_header.index
 
     # Verify all prerequisite CALs are cached
     for i in range(chunk_index):
         if i not in cached_cals:
-            return ChunkExecutionStatusV1(
+            return PayloadStatusV1(
                 status="INSUFFICIENT_INFORMATION",
-                chunk_index=chunk_index,
                 error=f"Missing CAL {i}, have {list(cached_cals.keys())}"
             )
 
     # Verify chunk's own CAL is cached
     if chunk_index not in cached_cals:
-        return ChunkExecutionStatusV1(
+        return PayloadStatusV1(
             status="INSUFFICIENT_INFORMATION",
-            chunk_index=chunk_index,
             error=f"Missing CAL {chunk_index}"
         )
+    cal = cached_cals[chunk_index]
 
     # Get parent block state
     parent_state = get_state(payload_header.parent_hash)
     if parent_state is None:
-        return ChunkExecutionStatusV1(
-            status="SYNCING",
-            chunk_index=chunk_index
+        return PayloadStatusV1(
+            status="SYNCING"
         )
 
     # Apply CALs 0..N-1 to reconstruct chunk pre-state
@@ -389,11 +415,10 @@ def el_execute_chunk(
         pre_state = apply_state_diffs(pre_state, cached_cals[i])
 
     # Verify CAL hash matches chunk header commitment (EIP-7928 format)
-    cal_hash = keccak256(cached_cals[chunk_index])  # CAL is RLP-encoded
+    cal_hash = keccak256(cal)  # CAL is RLP-encoded
     if cal_hash != chunk.chunk_header.chunk_access_list_hash:
-        return ChunkExecutionStatusV1(
+        return PayloadStatusV1(
             status="INVALID",
-            chunk_index=chunk_index,
             error="CAL hash mismatch"
         )
 
@@ -402,83 +427,82 @@ def el_execute_chunk(
         payload_header,
         pre_state,
         chunk.transactions,
-        cached_cals[chunk_index]
+        cal
     )
 
     if result.error:
-        return ChunkExecutionStatusV1(
+        return PayloadStatusV1(
             status="INVALID",
-            chunk_index=chunk_index,
             error=result.error
         )
 
-    return ChunkExecutionStatusV1(
-        status="VALID",
-        chunk_index=chunk_index
+    return PayloadStatusV1(
+        status="VALID"
     )
 ```
 
 ### Engine API
 
-Three new Engine API methods support chunked validation:
+Four new Engine API methods support chunked validation:
+
+#### `engine_newBlockHeaderV1`
+
+Replaces `engine_newPayloadV5`. Informes EL that new block is available and passes block data, except CALs and chunks. Must be called first, as other calls depend on this data.
+
+**Parameters:**
+- `payload_header`: `ExecutionPayloadHeader`
+- `beaconRoot`: `Hash32`
+- `blobHashes`: `List[Hash32]`
+- `executionRequests`: `List[Bytes]`
+
+**Returns:** PayloadStatusV1
 
 #### `engine_newChunkAccessListV1`
 
-Caches a CAL for subsequent chunk execution.
+Caches a CAL for subsequent chunk execution. Requires block data to have been sent via `engine_newBlockHeaderV1`.
 
 **Parameters:**
-- `payloadHeader`: `ExecutionPayloadHeader` - The execution payload header
+- `blockHash`: `Hash32` - The block hash
 - `chunkIndex`: `ChunkIndex` - Index of the chunk this CAL corresponds to
 - `chunkAccessList`: `ChunkAccessList` - RLP-encoded chunk access list
 
-**Returns:** `ChunkAccessListStatusV1`
+**Returns:** `PayloadStatusV1`
 
 #### `engine_executeChunkV1`
 
-Executes and validates a chunk. Requires all prerequisite CALs (indices 0 through N) to have been sent via `engine_newChunkAccessListV1`.
+Executes and validates a chunk. Requires block data to have been sent via `engine_newBlockHeaderV1`, and all prerequisite CALs (indices `0` through `N`) to have been sent via `engine_newChunkAccessListV1`.
 
 **Parameters:**
-- `payloadHeader`: `ExecutionPayloadHeader` - The execution payload header
+- `blockHash`: `Hash32` - The block hash
 - `chunk`: `ExecutionChunk` - The chunk to execute
 
-**Returns:** `ChunkExecutionStatusV1`
+**Returns:** `PayloadStatusV1`
 
 #### `engine_finalizeBlockV1`
 
 Finalizes block validation after all chunks have been executed. Verifies:
 - Chunk headers chain correctly: chunk N's `pre_chunk_*` fields equal chunk N-1's cumulative values
 - Final state root matches `payload_header.state_root`
-- Total gas/blob gas matches payload header values
+- All block header fields are valid
 
 **Parameters:**
 - `blockHash`: `Hash32` - Hash of the execution payload
 
-**Returns:** `PayloadFinalizeStatusV1`
+**Returns:** `PayloadStatusV1`
 
 #### Response Types
 
-```python
-class ChunkAccessListStatusV1:
-    status: str              # "ACCEPTED" | "INVALID" | "SYNCING"
-    chunk_index: ChunkIndex
-    error: Optional[str]     # Present if status is "INVALID"
+All new Engine API methods return `PayloadStatusV1` type, but `status` field has different meaning and values depending on the method. Following table defines all possible values and when they can be used.
 
-class ChunkExecutionStatusV1:
-    status: str              # "VALID" | "INVALID" | "INSUFFICIENT_INFORMATION" | "SYNCING"
-    chunk_index: ChunkIndex
-    error: Optional[str]     # Present if status is "INVALID" or "INSUFFICIENT_INFORMATION"
+| Status | Semantics | `newBlockHeader` | `newChunkAccessList` | `executeChunk` | `finalizeBlock` |
+|-|-|-|-|-|-|
+| `ACCEPTED` | BlockHeader/CAL accepted successfully | ✅ | ✅ | | |
+| `VALID` | Chunk/block executed correctly | | | ✅ | ✅ |
+| `INSUFFICIENT_INFORMATION` | Missing prerequisite CALs | | | ✅ | |
+| `INVALID` | Execution or validation failed | ✅ | ✅ | ✅ | ✅ |
+| `SYNCING` | Parent state not available (node syncing) | ✅ | ✅ | ✅ | ✅ |
 
-class PayloadFinalizeStatusV1:
-    status: str              # "VALID" | "INVALID" | "SYNCING"
-    error: Optional[str]     # Present if status is "INVALID"
-```
-
-**Status Semantics:**
-- `VALID`: Chunk/block executed correctly, state diffs match CAL
-- `INVALID`: Execution failed or state diffs do not match CAL
-- `INSUFFICIENT_INFORMATION`: Missing prerequisite CALs
-- `SYNCING`: Parent state not available (node syncing)
-- `ACCEPTED`: CAL cached successfully
+The `error` field is present if status is `INSUFFICIENT_INFORMATION` or `INVALID`.
 
 ## Rationale
 
@@ -497,7 +521,7 @@ The consensus layer orchestrates chunk execution because:
 1. **Consistency**: Existing CL-EL interaction follows CL-driven patterns (e.g., `engine_newPayload`).
 2. **Global View**: The CL tracks which CALs have arrived from gossip and can optimally schedule chunk execution based on availability.
 3. **Dependency Enforcement**: The CL ensures chunks execute only when prerequisites are satisfied.
-4. **Timeliness Tracking**: The CL determines whether sidecars arrived within attestation deadlines.
+4. **Timeliness Tracking**: The CL determines whether messages arrived within attestation deadlines.
 
 ### Separate CAL Propagation
 
@@ -505,7 +529,9 @@ Decoupling CALs from chunks provides:
 
 1. **Faster Propagation**: CALs (kilobytes of state diffs) propagate faster than chunks (megabytes of transactions), enabling earlier execution starts.
 2. **Parallelization**: Chunks can execute independently by applying prior CALs to reconstruct pre-states.
-3. **Extensibility**: CALs can be extended with proving metadata without modifying chunk structure.
+3. **State reads**: CALs allow us to start reading required state from db before transactions arrive.
+4. **StateRoot calculation**: EL can start calculating state root as soon as all CALs are received.
+5. **Extensibility**: CALs can be extended with proving metadata without modifying chunk structure.
 
 ### Semantic Chunking
 
@@ -519,9 +545,9 @@ Semantic chunking (transaction-aligned boundaries with gas limits) differs from 
 
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
-| `CHUNK_GAS_LIMIT` | 2^24 (16.7M) | Balances parallelization granularity with per-chunk overhead. Large enough for complex transactions, small enough for bounded ZK proving circuits. |
-| `MAX_CHUNKS_PER_BLOCK` | 256 | Supports ~4 Ggas blocks (256 × 16M). Conservative upper bound accommodating future gas limit increases. |
-| `MAX_TRANSACTIONS_PER_CHUNK` | 2^16 (65,536) | Accommodates chunks filled with minimal-gas transactions (21,000 gas ETH transfers) with margin for future gas cost reductions. |
+| `CHUNK_GAS_LIMIT` | `2^24` (~16.7M) | Balances parallelization granularity with per-chunk overhead. Large enough for complex transactions, small enough for bounded ZK proving circuits. |
+| `MAX_CHUNKS_PER_BLOCK` | `256` | Supports ~4 Ggas blocks (256 × 16M). Conservative upper bound accommodating future gas limit increases. |
+| `MAX_TRANSACTIONS_PER_CHUNK` | `2^16` (65,536) | Accommodates chunks filled with minimal-gas transactions (ETH transfer - 21,000 gas) with margin for future gas cost reductions. |
 
 ## Backwards Compatibility
 
@@ -529,10 +555,10 @@ This EIP introduces breaking changes requiring a coordinated hard fork:
 
 | Component | Change |
 |-----------|--------|
-| **Block Propagation** | Execution payloads propagate as chunk and CAL sidecars instead of monolithic payloads |
-| **Network Protocol** | New gossip topics for `ExecutionChunkSidecar` and `ChunkAccessListSidecar` |
-| **Engine API** | Three new methods: `engine_newChunkAccessListV1`, `engine_executeChunkV1`, `engine_finalizeBlockV1` |
-| **Fork Choice** | Three-phase validation (CAL reception, chunk validation, block finalization) |
+| **Block Propagation** | Execution payloads propagate as chunk and CAL messages instead of monolithic payloads |
+| **Network Protocol** | New gossip topics for `ExecutionChunkMessage` and `ChunkAccessListMessage` |
+| **Engine API** | Four new methods: `engine_newBlockHeaderV1`, `engine_newChunkAccessListV1`, `engine_executeChunkV1`, `engine_finalizeBlockV1` |
+| **Validation** | Three-phase validation (CAL reception, chunk validation, block finalization) |
 
 Post-fork, nodes must implement chunked validation to participate in consensus. Historical blocks remain unaffected.
 

--- a/EIPS/eip-8101.md
+++ b/EIPS/eip-8101.md
@@ -207,11 +207,13 @@ Chunks and CALs propagate on dedicated gossip topics:
 Nodes MUST validate messages before forwarding:
 
 **ExecutionChunkMessage validation:**
+
 1. Verify `signed_block_header.signature` is valid for the proposer at the given slot
 2. Verify `chunk.chunk_header.index < MAX_CHUNKS_PER_BLOCK`
 3. Verify `chunk.chunk_header.gas_used <= CHUNK_GAS_LIMIT`
 4. Verify `hash_tree_root(chunk.transactions) == chunk.chunk_header.txs_root`
 5. Verify inclusion proof:
+
     ```python
     gindex = get_generalized_index(BeaconBlockBody, 'chunk_headers_root', chunk.chunk_header.index)
     is_valid_merkle_branch(
@@ -224,10 +226,12 @@ Nodes MUST validate messages before forwarding:
     ```
 
 **ChunkAccessListMessage validation:**
+
 1. Verify `signed_block_header.signature` is valid for the proposer at the given slot
 2. Verify `chunk_index < MAX_CHUNKS_PER_BLOCK`
 3. Verify `len(chunk_access_list) <= MAX_CAL_SIZE`
 4. Verify inclusion proof:
+
     ```python
     gindex = get_generalized_index(BeaconBlockBody, 'chunk_access_lists_root', chunk_index)
     is_valid_merkle_branch(
@@ -450,6 +454,7 @@ Four new Engine API methods support chunked validation:
 Replaces `engine_newPayloadV5`. Informes EL that new block is available and passes block data, except CALs and chunks. Must be called first, as other calls depend on this data.
 
 **Parameters:**
+
 - `payload_header`: `ExecutionPayloadHeader`
 - `beaconRoot`: `Hash32`
 - `blobHashes`: `List[Hash32]`
@@ -462,6 +467,7 @@ Replaces `engine_newPayloadV5`. Informes EL that new block is available and pass
 Caches a CAL for subsequent chunk execution. Requires block data to have been sent via `engine_newBlockHeaderV1`.
 
 **Parameters:**
+
 - `blockHash`: `Hash32` - The block hash
 - `chunkIndex`: `ChunkIndex` - Index of the chunk this CAL corresponds to
 - `chunkAccessList`: `ChunkAccessList` - RLP-encoded chunk access list
@@ -473,6 +479,7 @@ Caches a CAL for subsequent chunk execution. Requires block data to have been se
 Executes and validates a chunk. Requires block data to have been sent via `engine_newBlockHeaderV1`, and all prerequisite CALs (indices `0` through `N`) to have been sent via `engine_newChunkAccessListV1`.
 
 **Parameters:**
+
 - `blockHash`: `Hash32` - The block hash
 - `chunk`: `ExecutionChunk` - The chunk to execute
 
@@ -481,11 +488,13 @@ Executes and validates a chunk. Requires block data to have been sent via `engin
 #### `engine_finalizeBlockV1`
 
 Finalizes block validation after all chunks have been executed. Verifies:
+
 - Chunk headers chain correctly: chunk N's `pre_chunk_*` fields equal chunk N-1's cumulative values
 - Final state root matches `payload_header.state_root`
 - All block header fields are valid
 
 **Parameters:**
+
 - `blockHash`: `Hash32` - Hash of the execution payload
 
 **Returns:** `PayloadStatusV1`


### PR DESCRIPTION
Update to the spec so it's more aligned to prototype that I made.

Few highlighted changes:
- Inclusion proof now proves that chunk_header/CAL is included in the beacon block body (instead to `chunk_headers_root`/`chunk_access_lists_root`)
    - It's possible that we receive CAL/chunk before we receive beacon block, and this allows us to validate it (in this case, we don't have access to `chunk_headers_root`/`chunk_access_lists_root`)
- Only 2 new topics (one for CALs, one for chunks) - subnets
    - If everybody has to subscribe to every subnet, then they don't make sense
    - To make naming consistent, I now use "message" instead of "sidecar"
- Clarify that `ExecutionPayloadHeader` replaces `ExecutionPayload`
    - `chunk_count` is added as a field
- Rework Engine API
    - add `engine_newBlockHeaderV1`

Feel free to modify it any way you see fit