### PR TITLE
Define expiry check in EVM

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -91,7 +91,7 @@ Frame executes as regular call where the caller address is `ENTRY_POINT`.
 
 ##### `VERIFY` Mode
 
-Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction, or to perform a protocol-defined check (see [Expiry Verifier Frame](#expiry-verifier-frame)). The frame MAY call `APPROVE` to grant authorization. If the frame reverts, the whole transaction is invalid.
+Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. The frame may call `APPROVE` to grant authorization. If the frame reverts, the whole transaction is invalid.
 
 The execution behaves the same as `STATICCALL` for user code: state cannot otherwise be modified. The `APPROVE` opcode is the only exception and applies its protocol-defined effects, including approval updates and, for payment scopes, nonce increment and gas-charge collection.
 
@@ -177,30 +177,67 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
 
 #### Expiry Verifier Frame
 
-A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It performs a protocol-level deadline check against the block timestamp and runs no EVM code.
+A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as an 8-byte unsigned big-endian expiry timestamp. The call reverts unless `block.timestamp <= expiry_timestamp`.
 
 An expiry verifier frame is invalid unless all of the following hold:
 
 - `frame.flags == 0`,
-- `frame.gas_limit == 0`,
 - `frame.value == 0`, and
 - `len(frame.data) == EXPIRY_DATA_LENGTH`.
 
-A transaction MUST contain at most one expiry verifier frame.
+A transaction can contain at most one expiry verifier frame.
 
-When the protocol processes an expiry verifier frame:
+At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`. The expiry verifier contract's runtime code must be:
 
-```python
-expiry_timestamp = int.from_bytes(frame.data, "big")
-if block.header.timestamp > expiry_timestamp:
-    revert()
+```asm
+push1 0x08
+calldatasize
+eq
+push1 0x0a
+jumpi
+push0
+push0
+revert
+
+jumpdest
+push0
+calldataload
+push1 0xc0
+shr
+timestamp
+gt
+push1 0x16
+jumpi
+stop
+
+jumpdest
+push0
+push0
+revert
 ```
 
-If the check passes, the frame succeeds. `default_code` is not invoked, no contract is called, and the frame's only gas cost is `FRAME_TX_PER_FRAME_COST` for its receipt entry. The receipt entry on success is `[status=1, gas_used=0, logs=[]]`.
+The runtime bytecode is:
 
-The block's timestamp is read from the block header at the consensus layer, the same way the nonce check reads `state[tx.sender].nonce`; the `TIMESTAMP` opcode is never invoked.
+```text
+0x60083614600a575f5ffd5b5f3560c01c4211601657005b5f5ffd
+```
 
-`EXPIRY_VERIFIER` is a protocol-defined distinguished address. It is not specified as a deployed contract or precompile, and contracts MUST NOT assume anything about its code, balance, or caller type beyond address equality. The special handling above applies only when targeted by a `VERIFY` frame; a `SENDER` frame `CALL`ing `EXPIRY_VERIFIER` retains standard `CALL` semantics.
+Equivalently, the runtime behavior is:
+
+```python
+if len(evm.calldata) != EXPIRY_DATA_LENGTH:
+    revert()
+
+expiry_timestamp = int.from_bytes(evm.calldata, "big")
+if evm.timestamp > expiry_timestamp:
+    revert()
+
+stop()
+```
+
+If the check passes, the frame succeeds with no return data and no logs. The frame consumes gas according to normal EVM execution rules. Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted in this special `VERIFY` frame when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`.
+
+Clients may omit the explicit EVM execution and directly perform the expiry check above, provided the externally observable result is identical to executing the canonical contract. Note: While this is a valid optimization for Ethereum mainnet, it could be problematic on non-mainnet situations in case a different contract is used.
 
 ### New Opcodes
 
@@ -366,7 +403,6 @@ Initialize with transaction-scoped variables:
 Then for each call frame:
 
 1. Let `resolved_target = frame.target if frame.target is not null else tx.sender`, then execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, `value`, and `data`.
-   - If `frame.mode == VERIFY` and `frame.target == EXPIRY_VERIFIER`, the call is replaced by the protocol-defined check from [Expiry Verifier Frame](#expiry-verifier-frame); none of the bullets below apply.
    - If mode is `SENDER`:
        - `sender_approved` must be `true`. If not, the transaction is invalid.
        - Set `caller` as `tx.sender`.
@@ -579,10 +615,11 @@ Public mempool rules apply only to the validation prefix. Once `payer_approved =
 A frame transaction is eligible for public mempool propagation only if its validation prefix depends exclusively on:
 
 1. transaction fields, including the canonical signature hash,
-2. the sender's nonce, code, and storage,
-3. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
-4. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
-5. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
+2. the block timestamp as read by an expiry verifier frame,
+3. the sender's nonce, code, and storage,
+4. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
+5. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
+6. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
 
 Any dependency on third-party mutable state outside these categories must result in rejection by the public mempool.
 
@@ -596,7 +633,7 @@ While the frames are designed to be generic, we refine some frame modes for the 
 | `deploy`  | DEFAULT | Deploys a new smart account, typically via a deterministic factory such as the [EIP-7997](./eip-7997.md) predeploy |
 | `only_verify`  | VERIFY  | Validates the transaction and approves only the sender |
 | `pay`  | VERIFY | Validates the transaction and approves only the payer |
-| `expiry_verify` | VERIFY | Performs the protocol-level expiry check (target = `EXPIRY_VERIFIER`) |
+| `expiry_verify` | VERIFY | Calls the expiry verifier contract (target = `EXPIRY_VERIFIER`) |
 | `user_op` | SENDER | Executes the intended user operation |
 | `post_op` | DEFAULT | Executes an optional post-op action as needed by the paymaster |
 
@@ -662,7 +699,7 @@ An `expiry_verify` frame MAY appear at any position in the frame list. For the p
 
 A node MUST drop a frame transaction from the public mempool if it contains an `expiry_verify` frame whose deadline is less than the node's view of the current block timestamp at any point.
 
-Expiry verifier frames are not subject to the validation trace rules, banned-opcode rules, or storage-dependency tracking, and they do not consume `MAX_VERIFY_GAS`, since no EVM code executes.
+Expiry verifier frames are not subject to the validation trace rules, storage-dependency tracking, or `MAX_VERIFY_GAS`. The `TIMESTAMP` opcode is permitted only for the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same deadline check without explicit EVM execution.
 
 #### Canonical Paymaster Exception
 
@@ -690,6 +727,7 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BLOCKHASH (0x40)
 - COINBASE (0x41)
 - TIMESTAMP (0x42)
+    - Except in an expiry verifier frame executing the canonical runtime code at `EXPIRY_VERIFIER`.
 - NUMBER (0x43)
 - PREVRANDAO/DIFFICULTY (0x44)
 - GASLIMIT (0x45)


### PR DESCRIPTION
Was thinking something more like 4788 where we define the EVM behavior, but clients are free to implement optimization that does not invoke EVM.